### PR TITLE
Fix 302 error when setting PS1 as server IP

### DIFF
--- a/esp
+++ b/esp
@@ -332,7 +332,7 @@ esp_help_sys-info(){
 # -------------------
 
 alias lsip='ifconfig | grep "inet addr"| grep -v "127.0.0.1"';
-alias lsip-real="curl -s http://cpanel.net/showip.cgi";
+alias lsip-real="curl -s http://cpanel.com/showip.cgi";
 alias lsip-mainip="strings /var/cpanel/mainip";
 alias ips=$(ifconfig | awk '/inet/ {if ($2!~/127.0|:$/) print $2}' | awk -F: '{print "echo "$2}');
 


### PR DESCRIPTION
cpanel.net/showip.cgi now returns a 302 when curled. Updated to cpanel.com/showip.cgi to address this.